### PR TITLE
IMPLEMENT_THREAD_LOCAL macro now named THREAD_LOCAL

### DIFF
--- a/ext_geoip.cpp
+++ b/ext_geoip.cpp
@@ -755,7 +755,7 @@ struct geoipGlobals {
     std::string custom_directory;
 };
 
-IMPLEMENT_THREAD_LOCAL(geoipGlobals, s_geoip_globals);
+THREAD_LOCAL(geoipGlobals, s_geoip_globals);
 
 class geoipExtension: public Extension {
     public:


### PR DESCRIPTION
doesnt compile against the latest HHVM source otherwise for me